### PR TITLE
single newline

### DIFF
--- a/pkg/yamlreader/node_readfile_test.go
+++ b/pkg/yamlreader/node_readfile_test.go
@@ -30,7 +30,7 @@ func TestReadFile(t *testing.T) {
 		FileName: getTestFile(t),
 		Line:     2,
 		Column:   1,
-		Comment:  "# Head Comment\n\n# Line Comment",
+		Comment:  "# Head Comment\n# Line Comment",
 		Kind:     StringNode,
 		Tag:      "!!str",
 		Raw:      "Hello World",

--- a/pkg/yamlreader/node_unmarshalyaml.go
+++ b/pkg/yamlreader/node_unmarshalyaml.go
@@ -16,7 +16,7 @@ func (n *Node) unmarshalYAML(yamlNode *yaml.Node, recursionDetection map[*yaml.N
 	n.Tag = yamlNode.ShortTag()
 	n.Line = yamlNode.Line
 	n.Column = yamlNode.Column
-	n.Comment = strings.Trim(yamlNode.HeadComment+"\n\n"+yamlNode.LineComment, "\n")
+	n.Comment = strings.Trim(yamlNode.HeadComment+"\n"+yamlNode.LineComment, "\n")
 
 	switch yamlNode.Kind {
 	case yaml.DocumentNode:


### PR DESCRIPTION
Make round-trips to yaml and back easier by allowing the whole comment to be put in the head comment without risking losing some of the comment due to a double 
newline.
